### PR TITLE
CUBE-1 | documentation moved to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WikiaActivityLogger
 A simple tool built in [Node.js](https://nodejs.org) for logging activity of a [Wikia](http://community.wikia.com) wiki through several transports (currently only supported transports are [Discord](https://discordapp.com) and [Slack](https://slack.com)).
 
-Documentation can be found [here](http://kocka.wikia.com/wiki/WikiaActivityLogger)
+Documentation can be found [here](http://dev.wikia.com/wiki/WikiaActivityLogger)
 
 ## TODO
 - Better fetch system? Like really, polling isn't a good idea at all but I've no idea what other to use


### PR DESCRIPTION
I've changed the link from _kocka.wikia.com/..._ to _dev.wikia.com/..._ 