### PR TITLE
📝Parse package.json instead of process.env

### DIFF
--- a/controllers/cli/index.js
+++ b/controllers/cli/index.js
@@ -8,8 +8,8 @@
  * Importing modules
  */
 const Controller = require('../controller.js'),
-      util = require('../../includes/util.js');
-
+      util = require('../../includes/util.js'),
+      packageJSON = require('../../package.json');
 /**
  * Colors used in console methods
  */
@@ -43,8 +43,8 @@ class CLI extends Controller {
         const env = process.env;
         this._info(`
             =====
-            Welcome to ${env.npm_package_name} v${env.npm_package_version}!
-            Documentation can be found at ${env.npm_package_homepage}
+            Welcome to ${packageJSON.name} v${packageJSON.version}!
+            Documentation can be found at ${packageJSON.homepage}
             =====
         `);
     }

--- a/includes/wiki.js
+++ b/includes/wiki.js
@@ -4,7 +4,8 @@
  * Importing modules
  */
 const io = require('./io.js'),
-      util = require('./util.js');
+      util = require('./util.js'),
+      package = require('./../package.json');
 
 /**
  * Constants
@@ -246,7 +247,7 @@ class Wiki {
     _initInterval() {
         this._hook('initInterval');
         if(this.config.welcome) {
-            this.transport.send(['start', process.env.npm_package_name, process.env.npm_package_version]);
+            this.transport.send(['start', package.name, package.version]);
         }
         this.interval = setInterval(this._update.bind(this), (this.config.interval || 500));
     }

--- a/includes/wiki.js
+++ b/includes/wiki.js
@@ -5,7 +5,7 @@
  */
 const io = require('./io.js'),
       util = require('./util.js'),
-      package = require('./../package.json');
+      packageJson = require('./../package.json');
 
 /**
  * Constants
@@ -247,7 +247,7 @@ class Wiki {
     _initInterval() {
         this._hook('initInterval');
         if(this.config.welcome) {
-            this.transport.send(['start', package.name, package.version]);
+            this.transport.send(['start', packageJson.name, packageJson.version]);
         }
         this.interval = setInterval(this._update.bind(this), (this.config.interval || 500));
     }

--- a/includes/wiki.js
+++ b/includes/wiki.js
@@ -5,7 +5,7 @@
  */
 const io = require('./io.js'),
       util = require('./util.js'),
-      packageJson = require('./../package.json');
+      packageJSON = require('./../package.json');
 
 /**
  * Constants
@@ -247,7 +247,7 @@ class Wiki {
     _initInterval() {
         this._hook('initInterval');
         if(this.config.welcome) {
-            this.transport.send(['start', packageJson.name, packageJson.version]);
+            this.transport.send(['start', packageJSON.name, packageJSON.version]);
         }
         this.interval = setInterval(this._update.bind(this), (this.config.interval || 500));
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wikia-activity-logger",
-    "version": "1.5.8",
+    "version": "1.5.9",
     "description": "Logs activity of a Wikia wiki through different transports",
     "keywords": [
         "wikia",


### PR DESCRIPTION
> _"the new version of npm appanrently doesn't expose process.env.npm_* variables so I'll have to load package.json from the places that used these variables."

Fixes #30.
